### PR TITLE
Added functionality to trigger automations by name through MQTT messages

### DIFF
--- a/dist/automations.js
+++ b/dist/automations.js
@@ -48,6 +48,10 @@ var ConfigPayload;
     ConfigPayload["TURN_ON"] = "turn_on";
     ConfigPayload["TURN_OFF"] = "turn_off";
 })(ConfigPayload || (ConfigPayload = {}));
+var MessagePayload;
+(function (MessagePayload) {
+    MessagePayload["EXECUTE"] = "execute";
+})(MessagePayload || (MessagePayload = {}));
 class InternalLogger {
     constructor() { }
     debug(message, ...args) {
@@ -78,6 +82,8 @@ class AutomationsExtension {
         this.mqttBaseTopic = settings.get().mqtt.base_topic;
         this.triggerForTimeouts = {};
         this.turnOffAfterTimeouts = {};
+        this.automationsTopic = 'zigbee2mqtt-automations';
+        this.topicRegex = new RegExp(`^${this.automationsTopic}\/(.*)`);
         this.logger.info(`[Automations] Loading automation.js`);
         if (!this.parseConfig())
             return;
@@ -661,10 +667,32 @@ class AutomationsExtension {
             this.runAutomationIfMatches(automation, update, from, to);
         }
     }
+    processMessage(message) {
+        const match = message.topic.match(this.topicRegex);
+        if (match) {
+            for (const automations of Object.values(this.eventAutomations)) {
+                for (const automation of automations) {
+                    if (automation.name == match[1]) {
+                        this.logger.info(`[Automations] MQTT message for [${match[1]}]: ${message.message}`);
+                        switch (message.message) {
+                            case MessagePayload.EXECUTE:
+                                this.runActions(automation, automation.action);
+                                break;
+                        }
+                        return;
+                    }
+                }
+            }
+        }
+    }
     async start() {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         this.eventBus.onStateChange(this, (data) => {
             this.findAndRun(data.entity.name, data.update, data.from, data.to);
+        });
+        this.mqtt.subscribe(`${this.automationsTopic}/+`);
+        this.eventBus.onMQTTMessage(this, (data) => {
+            this.processMessage(data);
         });
     }
     async stop() {


### PR DESCRIPTION
As per feature request in https://github.com/Luligu/zigbee2mqtt-automations/issues/6.

This change leverages the existing Zigbee2MQTT eventBus and MQTT subscription mechanisms:

1. It subscribes to topic `zigbee2mqtt-automations/+`
2. [eventBus.onMQTTMessage](https://github.com/Koenkk/zigbee2mqtt/blob/69f728295224c06ce509eb3afdf611b37ca8fa37/lib/eventBus.ts#L146) is used to recieve notifications on MQTT messages
3. When a message is received the topic is regex matched against `zigbee2mqtt-automations/(.*)`
4. The captured value is matched against the defined automations in automations.yaml
5. When a match is found, the requested automation is triggered using [this.runActions](https://github.com/Luligu/zigbee2mqtt-automations/blob/master/src/automations.ts#L653) (bypassing any trigger conditions)

Note: Currently only a message payload of `execute` is supported.
Perhaps other options can be added in the future as the need arises.