### PR TITLE
Update against zigbee2mqtt extension signature changes

### DIFF
--- a/dist/automations.js
+++ b/dist/automations.js
@@ -69,12 +69,15 @@ class InternalLogger {
     }
 }
 class AutomationsExtension {
-    constructor(zigbee, mqtt, state, publishEntityState, eventBus, settings, logger) {
+    constructor(zigbee, mqtt, state, publishEntityState, eventBus, enableDisableExtension, restartCallback, addExtension, settings, logger) {
         this.zigbee = zigbee;
         this.mqtt = mqtt;
         this.state = state;
         this.publishEntityState = publishEntityState;
         this.eventBus = eventBus;
+        this.enableDisableExtension = enableDisableExtension;
+        this.restartCallback = restartCallback;
+        this.addExtension = addExtension;
         this.settings = settings;
         this.logger = logger;
         this.eventAutomations = {};

--- a/src/automations.ts
+++ b/src/automations.ts
@@ -22,6 +22,7 @@ import type Zigbee from 'zigbee2mqtt/dist/zigbee';
 import type MQTT from 'zigbee2mqtt/dist/mqtt';
 import type State from 'zigbee2mqtt/dist/state';
 import type EventBus from 'zigbee2mqtt/dist/eventBus';
+import type Extension from 'zigbee2mqtt/dist/extension/extension';
 import type Settings from 'zigbee2mqtt/dist/util/settings';
 import type Logger from 'zigbee2mqtt/dist/util/logger';
 
@@ -232,6 +233,9 @@ class AutomationsExtension {
     protected state: State,
     protected publishEntityState: unknown,
     protected eventBus: EventBus,
+    protected enableDisableExtension: (enable: boolean, name: string) => Promise<void>,
+    protected restartCallback: () => Promise<void>,
+    protected addExtension: (extension: Extension) => Promise<void>,
     protected settings: typeof Settings,
     protected logger: typeof Logger,
   ) {


### PR DESCRIPTION
The upcoming zigbee2mqtt v2 changes require a new entry function signature for extensions.
This PR updates zigbee2mqtt-automations to align with the change.

Upcoming changes are discussed in:
https://github.com/Koenkk/zigbee2mqtt/discussions/24198

New z2m v2.0 signature:
https://github.com/Koenkk/zigbee2mqtt/blob/dev/lib/extension/externalExtensions.ts#L43-L54